### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
   </scm>
   <properties>
     <jug-lgpl.version>2.0.0</jug-lgpl.version>
-    <commons-codec.version>1.3</commons-codec.version>
     <junit.version>4.9</junit.version>
     <system-rules.version>1.16.1</system-rules.version>
   </properties>
@@ -31,7 +30,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.